### PR TITLE
Update controls for both minigames

### DIFF
--- a/dodge.html
+++ b/dodge.html
@@ -58,7 +58,7 @@
 <body>
   <div id="overlay">
     <h1>🤖 Robot Blaster</h1>
-    <p>Use ← → to move<br>Press Space to shoot<br>Survive 30 seconds!</p>
+    <p>Use A / D to move<br>Press Space to shoot<br>Survive 30 seconds!</p>
     <button id="startBtn">Start Game</button>
   </div>
 
@@ -119,11 +119,11 @@
     document.addEventListener("keydown", e => {
       keys[e.code] = true;
 
-      // Prevent default arrow-key scrolling
-      if (["ArrowUp","ArrowDown","ArrowLeft","ArrowRight","Space"].includes(e.code)) {
+      // Prevent default when using space to shoot
+      if (e.code === "Space") {
         e.preventDefault();
+        shoot();
       }
-      if (e.code === "Space") shoot();
     });
 
     document.addEventListener("keyup", e => {
@@ -149,8 +149,8 @@
 
     function update() {
       /* Move player */
-      if (keys["ArrowLeft"])  player.x -= PLAYER_SPEED;
-      if (keys["ArrowRight"]) player.x += PLAYER_SPEED;
+      if (keys["KeyA"]) player.x -= PLAYER_SPEED;
+      if (keys["KeyD"]) player.x += PLAYER_SPEED;
 
       // Clamp to canvas
       player.x = Math.max(0, Math.min(canvas.width - PLAYER_SIZE, player.x));

--- a/tank.html
+++ b/tank.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Tank Blaster — Mouse Turret & True Tank Controls</title>
+  <title>Tank Blaster — Keyboard Turret Controls</title>
   <style>
     body,html{margin:0;padding:0;height:100%;background:#0e0e0e;color:#fafafa;font-family:Arial,Helvetica,sans-serif;overflow:hidden}
-    #gameCanvas{display:block;margin:auto;background:#111a27;border:4px solid #2c3e50;border-radius:8px;cursor:crosshair}
+    #gameCanvas{display:block;margin:auto;background:#111a27;border:4px solid #2c3e50;border-radius:8px}
     #overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;background:rgba(0,0,0,.8);gap:1rem;text-align:center;padding:1rem}
     #overlay h1{font-size:2.2rem;margin:0}
     #overlay button{padding:.75rem 1.5rem;font-size:1.1rem;background:#27ae60;border:none;border-radius:6px;cursor:pointer;color:#fff;transition:transform .1s}
@@ -15,7 +15,7 @@
 <body>
   <div id="overlay">
     <h1>🛡️ Tank Blaster</h1>
-    <p>← / → rotate • ↑ / ↓ drive • Mouse to aim • Click to fire<br>Survive 30 s and destroy the red squares!</p>
+    <p>A / D rotate • W / S drive • Q / E aim • Space to fire<br>Survive 30 s and destroy the red squares!</p>
     <button id="startBtn">Start Game</button>
   </div>
 
@@ -28,17 +28,18 @@ const ctx      = canvas.getContext('2d');
 const overlay  = document.getElementById('overlay');
 const startBtn = document.getElementById('startBtn');
 
-const PLAYER_SIZE=36,BULLET_RADIUS=4,ENEMY_SIZE=28,ROTATE_SPEED=0.04,MOVE_SPEED=1,
+const PLAYER_SIZE=36,BULLET_RADIUS=4,ENEMY_SIZE=28,ROTATE_SPEED=0.04,TURRET_ROTATE_SPEED=0.05,MOVE_SPEED=1,
       BULLET_SPEED=6,ENEMY_SPEED=1,SPAWN_INTERVAL=1200,GAME_DURATION=30000,SCORE_SLOT=2;
 
 let keys={},bullets=[],enemies=[],score=0,startTime=0,lastSpawn=0,animationId=0;
 
 const player={x:canvas.width/2,y:canvas.height-PLAYER_SIZE*2,bodyAngle:-Math.PI/2,turretAngle:-Math.PI/2};
 
-addEventListener('keydown',e=>{keys[e.code]=true;if(['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code))e.preventDefault();});
+addEventListener('keydown',e=>{
+  keys[e.code]=true;
+  if(e.code==='Space'){e.preventDefault();shoot();}
+});
 addEventListener('keyup',e=>keys[e.code]=false);
-canvas.addEventListener('mousemove',e=>{const r=canvas.getBoundingClientRect();player.turretAngle=Math.atan2(e.clientY-r.top-player.y,e.clientX-r.left-player.x);});
-canvas.addEventListener('click',shoot);
 startBtn.addEventListener('click',startGame);
 
 function startGame(){resetGame();overlay.style.display='none';startTime=performance.now();lastSpawn=startTime;animationId=requestAnimationFrame(gameLoop);}
@@ -53,9 +54,10 @@ function spawnEnemy(){const edge=Math.floor(Math.random()*4);let x,y;if(edge===0
  enemies.push({x,y,vx:Math.cos(a)*s,vy:Math.sin(a)*s});}
 
 function update(){
-  if(keys.ArrowLeft)player.bodyAngle-=ROTATE_SPEED;if(keys.ArrowRight)player.bodyAngle+=ROTATE_SPEED;
-  const fx=Math.cos(player.bodyAngle),fy=Math.sin(player.bodyAngle);if(keys.ArrowUp){player.x+=fx*MOVE_SPEED;player.y+=fy*MOVE_SPEED;}
-  if(keys.ArrowDown){player.x-=fx*MOVE_SPEED;player.y-=fy*MOVE_SPEED;}
+  if(keys.KeyA)player.bodyAngle-=ROTATE_SPEED;if(keys.KeyD)player.bodyAngle+=ROTATE_SPEED;
+  if(keys.KeyQ)player.turretAngle-=TURRET_ROTATE_SPEED;if(keys.KeyE)player.turretAngle+=TURRET_ROTATE_SPEED;
+  const fx=Math.cos(player.bodyAngle),fy=Math.sin(player.bodyAngle);if(keys.KeyW){player.x+=fx*MOVE_SPEED;player.y+=fy*MOVE_SPEED;}
+  if(keys.KeyS){player.x-=fx*MOVE_SPEED;player.y-=fy*MOVE_SPEED;}
   player.x=Math.max(PLAYER_SIZE/2,Math.min(canvas.width-PLAYER_SIZE/2,player.x));
   player.y=Math.max(PLAYER_SIZE/2,Math.min(canvas.height-PLAYER_SIZE/2,player.y));
 


### PR DESCRIPTION
## Summary
- switch Dodge game movement controls to `A` and `D`
- update Robot Blaster instructions
- replace arrow key handling with `A/D`
- change Tank Blaster to use keyboard aiming and firing
- remove mouse cursor and update instructions
- use `WASD` for movement in Tank Blaster instead of arrow keys

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c7d41a6ac832bb54fce05e572284d