### PR TITLE
Remove preview button and auto-update card

### DIFF
--- a/cardgen.html
+++ b/cardgen.html
@@ -56,15 +56,11 @@
     button:hover {
       transform: translateY(-2px);
     }
-    #preview-btn {
-      background: #2563eb;
-      color: #fff;
-      margin-right: 0.5rem;
-    }
+    /* Preview button removed */
     #download-btn {
       background: #10b981;
       color: #fff;
-      display: none;
+      display: inline-block;
     }
   </style>
 
@@ -83,7 +79,6 @@
     </div>
   </div>
 
-  <button id="preview-btn">Preview Card</button>
   <button id="download-btn">Download PNG</button>
 
   <script>
@@ -123,11 +118,9 @@
       document.getElementById("card").style.borderColor = borderColor;
     }
 
-    // ── Button handlers ───────────────────────────────
-    document.getElementById("preview-btn").addEventListener("click", () => {
-      buildCard();
-      document.getElementById("download-btn").style.display = "inline-block";
-    });
+    // ── Initialize and periodic updates ───────────────
+    buildCard();
+    setInterval(buildCard, 60000); // update every minute
 
     document.getElementById("download-btn").addEventListener("click", () => {
       html2canvas(document.getElementById("card"), { scale: 2 }).then((canvas) => {


### PR DESCRIPTION
## Summary
- remove the preview button from **cardgen.html**
- show the download button by default
- update card scores every minute automatically

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6863148353b0832bafa65dd8a119ff38