### PR TITLE
Implement score sheet parsing and star rank adjustment

### DIFF
--- a/cardgen/index.html
+++ b/cardgen/index.html
@@ -86,6 +86,7 @@
   <script src="../shared.js"></script>
   <script src="description.js"></script>
   <script src="storage.js"></script>
+  <script src="scoreSheet.js"></script>
   <script src="main.js"></script>
 </head>
 

--- a/cardgen/main.js
+++ b/cardgen/main.js
@@ -30,7 +30,20 @@ function buildCard() {
 
   updateCodeBonus();
   const scoreForStars = total + window.codeBonus;
-  const starCount = Math.min(12, Math.round((scoreForStars / MAX_TOTAL) * 12));
+
+  let rank = 0;
+  if (window.robotInfo) {
+    try {
+      const sheet = JSON.parse(localStorage.getItem("botScoreSheet") || "[]");
+      const me = sheet.find(
+        (r) => r.name === `${window.robotInfo.name} ${window.robotInfo.version}`
+      );
+      if (me) rank = me.rank || 0;
+    } catch {}
+  }
+
+  const baseStars = Math.min(12, Math.round((scoreForStars / MAX_TOTAL) * 12));
+  const starCount = Math.max(0, baseStars - rank);
   starEl.textContent = "★".repeat(starCount);
 
   const hue = Math.max(0, Math.min(120, total));

--- a/cardgen/scoreSheet.js
+++ b/cardgen/scoreSheet.js
@@ -1,0 +1,105 @@
+// Utilities for handling Robocode-style score sheets
+
+/**
+ * @typedef {Object} ScoreRow
+ * @property {number} rank          // Field 1
+ * @property {string} name          // Field 2
+ * @property {number} survival      // Field 3
+ * @property {number} lastSurvivor  // Field 4
+ * @property {number} bullet        // Field 5
+ * @property {number} bonus         // Field 7
+ * @property {string} raw           // Original line
+ */
+
+/**
+ * Parse a raw score sheet string produced by a tournament.
+ * Each line should be tab separated with the fixed field order described
+ * in the README. Only the first seven columns are used.
+ *
+ * @param {string} raw
+ * @returns {ScoreRow[]}
+ */
+function parseScoreSheet(raw) {
+  if (typeof raw !== 'string') return [];
+  return raw
+    .trim()
+    .split(/\r?\n/) // split on newlines
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('\t');
+      return {
+        rank: Number(parts[0]) || 0,
+        name: parts[1] || '',
+        survival: Number(parts[2]) || 0,
+        lastSurvivor: Number(parts[3]) || 0,
+        bullet: Number(parts[4]) || 0,
+        bonus: Number(parts[6]) || 0,
+        raw: line,
+      };
+    });
+}
+
+/**
+ * Parse the given score sheet string and persist it under
+ * localStorage['botScoreSheet'].
+ *
+ * @param {string} raw
+ */
+function saveScoreSheet(raw) {
+  const scores = parseScoreSheet(raw);
+  try {
+    localStorage.setItem('botScoreSheet', JSON.stringify(scores));
+  } catch (err) {
+    console.error('Failed to store score sheet', err);
+  }
+}
+
+/**
+ * Get tint information for a particular row relative to the entire sheet.
+ * This computes tints for survival (green), bullet damage (blue) and bonus
+ * (orange) according to the specification.
+ *
+ * @param {ScoreRow} row  The row to evaluate
+ * @param {ScoreRow[]} all  All rows from the sheet
+ * @returns {{survivalTint:string, bulletTint:string, bonusTint:string}}
+ */
+function getTintInfo(row, all) {
+  if (!row || !Array.isArray(all) || all.length === 0) {
+    return { survivalTint: '', bulletTint: '', bonusTint: '' };
+  }
+
+  const survivalValues = all.map((r) => r.survival);
+  const bonusValues = all.map((r) => r.bonus);
+  const bulletValues = all.map((r) => r.bullet);
+
+  const minSurvival = Math.min.apply(null, survivalValues);
+  const maxSurvival = Math.max.apply(null, survivalValues);
+  const minBonus = Math.min.apply(null, bonusValues);
+  const maxBonus = Math.max.apply(null, bonusValues);
+  const maxBullet = Math.max.apply(null, bulletValues);
+
+  const survivalRange = maxSurvival - minSurvival || 1;
+  const bonusRange = maxBonus - minBonus || 1;
+
+  const survRatio = (row.survival - minSurvival) / survivalRange;
+  const bonusRatio = (row.bonus - minBonus) / bonusRange;
+
+  const survivalOpacity = Math.max(0, Math.min(1, survRatio)) * 0.3;
+  const bonusOpacity = Math.max(0, Math.min(1, bonusRatio)) * 0.3;
+
+  const survivalTint =
+    survivalOpacity > 0
+      ? `rgba(0,255,0,${survivalOpacity.toFixed(2)})`
+      : '';
+  const bonusTint =
+    bonusOpacity > 0 ? `rgba(255,165,0,${bonusOpacity.toFixed(2)})` : '';
+  const bulletTint = row.bullet === maxBullet ? 'rgba(0,0,255,0.3)' : '';
+
+  return { survivalTint, bulletTint, bonusTint };
+}
+
+// expose globals for non-module usage
+window.parseScoreSheet = parseScoreSheet;
+window.saveScoreSheet = saveScoreSheet;
+window.getTintInfo = getTintInfo;
+


### PR DESCRIPTION
## Summary
- add `scoreSheet.js` utility with parsing, saving, and tint calculations
- integrate score sheet utility in card generator page
- adjust star calculation based on bot rank

## Testing
- `node -e "require('./cardgen/scoreSheet.js')"` *(fails: window undefined)*


------
https://chatgpt.com/codex/tasks/task_e_68658ad8e084832bac35091509a3c21b