### PR TITLE
Add score-based card gradient

### DIFF
--- a/cardgen.html
+++ b/cardgen.html
@@ -259,8 +259,13 @@
       // Color theme — map total score (0-400) onto hue (0-120)
       const hue = Math.max(0, Math.min(120, total));
       const [r, g, b] = hslToRgb(hue / 360, 0.65, 0.5);
+      const [r1, g1, b1] = hslToRgb(hue / 360, 0.6, 0.85);
+      const [r2, g2, b2] = hslToRgb(hue / 360, 0.6, 0.35);
       const borderColor = `rgb(${r}, ${g}, ${b})`;
-      document.getElementById("card").style.borderColor = borderColor;
+      const gradient = `linear-gradient(135deg, rgb(${r1}, ${g1}, ${b1}), rgb(${r2}, ${g2}, ${b2}))`;
+      const card = document.getElementById("card");
+      card.style.borderColor = borderColor;
+      card.style.background = gradient;
     }
 
     // ── Initialize and periodic updates ───────────────

--- a/cardgen/main.js
+++ b/cardgen/main.js
@@ -48,8 +48,13 @@ function buildCard() {
 
   const hue = Math.max(0, Math.min(120, total));
   const [r, g, b] = hslToRgb(hue / 360, 0.65, 0.5);
+  const [r1, g1, b1] = hslToRgb(hue / 360, 0.6, 0.85);
+  const [r2, g2, b2] = hslToRgb(hue / 360, 0.6, 0.35);
   const borderColor = `rgb(${r}, ${g}, ${b})`;
-  document.getElementById("card").style.borderColor = borderColor;
+  const gradient = `linear-gradient(135deg, rgb(${r1}, ${g1}, ${b1}), rgb(${r2}, ${g2}, ${b2}))`;
+  const card = document.getElementById("card");
+  card.style.borderColor = borderColor;
+  card.style.background = gradient;
 }
 
 // DOM setup and event bindings


### PR DESCRIPTION
## Summary
- tweak card build logic to set a gradient background based on the user's score
- update inline script with the same gradient behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68659708bcc0832b8cd2cc77212cc455