### PR TITLE
Add role selector with color tint

### DIFF
--- a/cardgen/index.html
+++ b/cardgen/index.html
@@ -111,6 +111,17 @@
     <button id="edit-scoresheet-btn" type="button">Edit Scoresheet</button>
   </div>
 
+  <div style="margin-bottom:1rem;">
+    <label for="role-select">Role:</label>
+    <select id="role-select">
+      <option value="">-- Select --</option>
+      <option value="Explorer">Explorer</option>
+      <option value="Achiever">Achiever</option>
+      <option value="Competitor">Competitor</option>
+      <option value="Harmonizer">Harmonizer</option>
+    </select>
+  </div>
+
   <div style="margin-bottom:1rem; display:none;">
     <label for="code-input">Card code:</label>
     <input id="code-input" type="text" />
@@ -119,6 +130,7 @@
   <div class="preview-wrapper">
     <div id="card" class="card" style="display:none;">
       <div id="star-rating" style="font-size: large;" class="stars"></div>
+      <div id="player-role" class="player-role" style="text-align:center;font-weight:bold;margin-bottom:0.25rem;"></div>
       <img id="tank-image" src="" alt="Tank preview"
         style="width:100%;border-radius:0.5rem;margin-bottom:0.5rem;display:none;" />
       <h2 id="robot-name"></h2>

--- a/cardgen/main.js
+++ b/cardgen/main.js
@@ -5,6 +5,12 @@ const MAX_TOTAL = Object.values(MAX_SCORES).reduce((a, b) => a + b, 0);
 window.codeBonus = 0;
 window.robotInfo = null;
 window.intervalId = null;
+const ROLE_COLORS = {
+  Explorer: [128, 128, 128],
+  Achiever: [0, 128, 128],
+  Competitor: [218, 165, 32],
+  Harmonizer: [0, 128, 0],
+};
 
 function updateCodeBonus() {
   const code = document.getElementById("code-input").value.trim();
@@ -18,6 +24,8 @@ function updateCodeBonus() {
 function buildCard() {
   const statsEl = document.getElementById("stats");
   const starEl = document.getElementById("star-rating");
+  const roleTitleEl = document.getElementById("player-role");
+  const roleSelectEl = document.getElementById("role-select");
   statsEl.innerHTML = "";
 
   renderRobotMeta();
@@ -47,8 +55,20 @@ function buildCard() {
   starEl.textContent = "★".repeat(starCount);
 
   const hue = Math.max(0, Math.min(120, total));
-  const [r1, g1, b1] = hslToRgb(hue, 0.65, 0.4);
-  const [r2, g2, b2] = hslToRgb(hue, 0.65, 0.6);
+  let [r1, g1, b1] = hslToRgb(hue, 0.65, 0.4);
+  let [r2, g2, b2] = hslToRgb(hue, 0.65, 0.6);
+  const role = roleSelectEl.value || "";
+  roleTitleEl.textContent = role;
+  if (ROLE_COLORS[role]) {
+    const [tr, tg, tb] = ROLE_COLORS[role];
+    const mix = (c, t) => Math.round(c * 0.75 + t * 0.25);
+    r1 = mix(r1, tr);
+    g1 = mix(g1, tg);
+    b1 = mix(b1, tb);
+    r2 = mix(r2, tr);
+    g2 = mix(g2, tg);
+    b2 = mix(b2, tb);
+  }
   const gradient = `linear-gradient(135deg, rgb(${r1}, ${g1}, ${b1}), rgb(${r2}, ${g2}, ${b2}))`;
   const borderColor = `rgb(${r2}, ${g2}, ${b2})`;
   const cardEl = document.getElementById("card");
@@ -64,9 +84,16 @@ window.addEventListener('DOMContentLoaded', () => {
   const imgEl = document.getElementById("tank-image");
   const cardEl = document.getElementById("card");
   const codeInputEl = document.getElementById("code-input");
+  const roleSelectEl = document.getElementById("role-select");
   const editImgBtn = document.getElementById("edit-image-btn");
   const editJsonBtn = document.getElementById("edit-json-btn");
   const editSheetBtn = document.getElementById("edit-scoresheet-btn");
+
+  roleSelectEl.value = localStorage.getItem("robotCard:role") || "";
+  roleSelectEl.addEventListener("change", () => {
+    localStorage.setItem("robotCard:role", roleSelectEl.value);
+    buildCard();
+  });
 
   codeInputEl.addEventListener("input", () => {
     updateCodeBonus();

--- a/cardgen/storage.js
+++ b/cardgen/storage.js
@@ -4,8 +4,10 @@ function loadStoredData() {
   const jsonUploadEl = document.getElementById("json-upload");
   const imgEl = document.getElementById("tank-image");
   const cardEl = document.getElementById("card");
+  const roleSelectEl = document.getElementById("role-select");
   const storedImg = localStorage.getItem("robotCard:image");
   const storedJson = localStorage.getItem("robotCard:json");
+  const storedRole = localStorage.getItem("robotCard:role");
   if (storedImg) {
     imgEl.src = storedImg;
     imgEl.style.display = "block";
@@ -14,7 +16,10 @@ function loadStoredData() {
   if (storedJson) {
     try { window.robotInfo = JSON.parse(storedJson); } catch { }
   }
-  if (storedImg || storedJson) {
+  if (storedRole) {
+    roleSelectEl.value = storedRole;
+  }
+  if (storedImg || storedJson || storedRole) {
     buildCard();
     if (!window.intervalId) window.intervalId = setInterval(buildCard, 60000);
   }
@@ -23,8 +28,10 @@ function loadStoredData() {
 function updateCardFromStorage() {
   const imgEl = document.getElementById("tank-image");
   const cardEl = document.getElementById("card");
+  const roleSelectEl = document.getElementById("role-select");
   const storedImg = localStorage.getItem("robotCard:image");
   const storedJson = localStorage.getItem("robotCard:json");
+  const storedRole = localStorage.getItem("robotCard:role");
   if (storedImg && storedImg !== imgEl.src) {
     imgEl.src = storedImg;
     imgEl.style.display = "block";
@@ -37,6 +44,9 @@ function updateCardFromStorage() {
         window.robotInfo = parsed;
       }
     } catch {}
+  }
+  if (storedRole) {
+    roleSelectEl.value = storedRole;
   }
   buildCard();
 }


### PR DESCRIPTION
## Summary
- add role picker to card generator UI
- show selected role on player card
- tint card colors based on chosen role
- store and load role from localStorage

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68683d953e74832b9bbfaa27e4b72216