### PR TITLE
Use role emoji on robot card

### DIFF
--- a/cardgen/index.html
+++ b/cardgen/index.html
@@ -30,6 +30,7 @@
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       border: 4px solid transparent;
       transition: border-color 0.3s ease;
+      position: relative;
     }
 
     .card h2 {
@@ -49,6 +50,13 @@
       color: #f1c40f;
       font-size: 1.25rem;
       margin-bottom: 0.25rem;
+    }
+
+    .player-role {
+      position: absolute;
+      top: 0.25rem;
+      left: 0.25rem;
+      font-size: 1.25rem;
     }
 
     /* ── Buttons ────────────────────────────────────── */
@@ -130,7 +138,7 @@
   <div class="preview-wrapper">
     <div id="card" class="card" style="display:none;">
       <div id="star-rating" style="font-size: large;" class="stars"></div>
-      <div id="player-role" class="player-role" style="text-align:center;font-weight:bold;margin-bottom:0.25rem;"></div>
+      <div id="player-role" class="player-role"></div>
       <img id="tank-image" src="" alt="Tank preview"
         style="width:100%;border-radius:0.5rem;margin-bottom:0.5rem;display:none;" />
       <h2 id="robot-name"></h2>

--- a/cardgen/main.js
+++ b/cardgen/main.js
@@ -11,6 +11,12 @@ const ROLE_COLORS = {
   Competitor: [218, 165, 32],
   Harmonizer: [0, 128, 0],
 };
+const ROLE_EMOJIS = {
+  Explorer: "✨",
+  Achiever: "🏆",
+  Competitor: "🔥",
+  Harmonizer: "🤝",
+};
 
 function updateCodeBonus() {
   const code = document.getElementById("code-input").value.trim();
@@ -58,7 +64,7 @@ function buildCard() {
   let [r1, g1, b1] = hslToRgb(hue, 0.65, 0.4);
   let [r2, g2, b2] = hslToRgb(hue, 0.65, 0.6);
   const role = roleSelectEl.value || "";
-  roleTitleEl.textContent = role;
+  roleTitleEl.textContent = ROLE_EMOJIS[role] || "";
   if (ROLE_COLORS[role]) {
     const [tr, tg, tb] = ROLE_COLORS[role];
     const mix = (c, t) => Math.round(c * 0.75 + t * 0.25);


### PR DESCRIPTION
## Summary
- show the player role as an emoji positioned in the top-left corner
- map each role to its emoji in JS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686841b244f0832b87f56f6e94bc9c34