### PR TITLE
Add logo and reposition player role emoji

### DIFF
--- a/cardgen/index.html
+++ b/cardgen/index.html
@@ -52,10 +52,18 @@
       margin-bottom: 0.25rem;
     }
 
-    .player-role {
+    .logo {
       position: absolute;
       top: 0.25rem;
       left: 0.25rem;
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
+    .player-role {
+      position: absolute;
+      top: 0.25rem;
+      right: 0.25rem;
       font-size: 1.25rem;
     }
 
@@ -137,8 +145,9 @@
 
   <div class="preview-wrapper">
     <div id="card" class="card" style="display:none;">
-      <div id="star-rating" style="font-size: large;" class="stars"></div>
+      <img src="icon.webp" alt="Infinite Mind logo" class="logo" />
       <div id="player-role" class="player-role"></div>
+      <div id="star-rating" style="font-size: large;" class="stars"></div>
       <img id="tank-image" src="" alt="Tank preview"
         style="width:100%;border-radius:0.5rem;margin-bottom:0.5rem;display:none;" />
       <h2 id="robot-name"></h2>


### PR DESCRIPTION
## Summary
- add a logo slot on the generated card
- move player role emoji to the right corner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686955f08f68832bbfe5940c292b97b3