### PR TITLE
Add difficulty setting to tank game

### DIFF
--- a/tank.html
+++ b/tank.html
@@ -15,7 +15,7 @@
 <body>
   <div id="overlay">
     <h1>🛡️ Tank Blaster</h1>
-    <p>A / D rotate • W / S drive • Q / E aim • Space to fire<br>Survive 30 s and destroy the red squares!</p>
+    <p>A / D rotate • W / S drive • Q / E aim • Space to fire<br>Survive 30 s and destroy the red squares! Use ?difficulty=n in the URL for a challenge.</p>
     <button id="startBtn">Start Game</button>
   </div>
 
@@ -27,6 +27,10 @@ const canvas   = document.getElementById('gameCanvas');
 const ctx      = canvas.getContext('2d');
 const overlay  = document.getElementById('overlay');
 const startBtn = document.getElementById('startBtn');
+
+const params = new URLSearchParams(location.search);
+let difficulty = parseInt(params.get('difficulty')) || 1;
+if (difficulty < 1) difficulty = 1;
 
 const PLAYER_SIZE=36,BULLET_RADIUS=4,ENEMY_SIZE=28,ROTATE_SPEED=0.04,TURRET_ROTATE_SPEED=0.05,MOVE_SPEED=1,
       BULLET_SPEED=6,ENEMY_SPEED=1,SPAWN_INTERVAL=1200,GAME_DURATION=30000,SCORE_SLOT=2;
@@ -51,7 +55,7 @@ function shoot(){const mx=player.x+Math.cos(player.turretAngle)*PLAYER_SIZE/2,my
 function spawnEnemy(){const edge=Math.floor(Math.random()*4);let x,y;if(edge===0){x=Math.random()*(canvas.width-ENEMY_SIZE);y=-ENEMY_SIZE;}
  else if(edge===1){x=canvas.width;y=Math.random()*(canvas.height-ENEMY_SIZE);}else if(edge===2){x=Math.random()*(canvas.width-ENEMY_SIZE);y=canvas.height;}
  else{x=-ENEMY_SIZE;y=Math.random()*(canvas.height-ENEMY_SIZE);}const a=Math.random()*Math.PI*2,s=ENEMY_SPEED*(0.7+Math.random()*0.6);
- enemies.push({x,y,vx:Math.cos(a)*s,vy:Math.sin(a)*s});}
+ enemies.push({x,y,vx:Math.cos(a)*s,vy:Math.sin(a)*s,hp:difficulty});}
 
 function update(){
   if(keys.KeyA){player.bodyAngle-=ROTATE_SPEED;player.turretAngle-=ROTATE_SPEED;}
@@ -70,7 +74,18 @@ function update(){
     if(e.x<=0||e.x>=canvas.width-ENEMY_SIZE){e.vx*=-1;e.x=Math.max(0,Math.min(canvas.width-ENEMY_SIZE,e.x));}
     if(e.y<=0||e.y>=canvas.height-ENEMY_SIZE){e.vy*=-1;e.y=Math.max(0,Math.min(canvas.height-ENEMY_SIZE,e.y));}});
 
-  bullets.forEach((b,bi)=>{enemies.forEach((e,ei)=>{if(b.x>e.x&&b.x<e.x+ENEMY_SIZE&&b.y>e.y&&b.y<e.y+ENEMY_SIZE){bullets.splice(bi,1);enemies.splice(ei,1);score++;}});});
+  for(let bi=bullets.length-1;bi>=0;bi--){
+    const b=bullets[bi];
+    for(let ei=enemies.length-1;ei>=0;ei--){
+      const e=enemies[ei];
+      if(b.x>e.x&&b.x<e.x+ENEMY_SIZE&&b.y>e.y&&b.y<e.y+ENEMY_SIZE){
+        bullets.splice(bi,1);
+        e.hp--;
+        if(e.hp<=0){enemies.splice(ei,1);score++;}
+        break;
+      }
+    }
+  }
   enemies.forEach(e=>{if(Math.hypot(player.x-(e.x+ENEMY_SIZE/2),player.y-(e.y+ENEMY_SIZE/2))<PLAYER_SIZE/2+ENEMY_SIZE/2)endGame(false);});
 
   if(performance.now()-startTime>=GAME_DURATION)endGame(true);
@@ -85,9 +100,14 @@ function draw(){
   ctx.fillRect(0,-3,PLAYER_SIZE/2,6);ctx.restore();
 
   ctx.fillStyle='#f4d03f';bullets.forEach(b=>{ctx.beginPath();ctx.arc(b.x,b.y,BULLET_RADIUS,0,Math.PI*2);ctx.fill();});
-  ctx.fillStyle='#e74c3c';enemies.forEach(e=>ctx.fillRect(e.x,e.y,ENEMY_SIZE,ENEMY_SIZE));
+  enemies.forEach(e=>{
+    const ratio=e.hp/difficulty;
+    const r=Math.floor(231*ratio),g=Math.floor(76*ratio),b=Math.floor(60*ratio);
+    ctx.fillStyle=`rgb(${r},${g},${b})`;
+    ctx.fillRect(e.x,e.y,ENEMY_SIZE,ENEMY_SIZE);
+  });
 
-  ctx.fillStyle='#fafafa';ctx.font='16px monospace';ctx.fillText(`High Score: ${getScore(SCORE_SLOT)} Score: ${score}`,10,20);
+  ctx.fillStyle='#fafafa';ctx.font='16px monospace';ctx.fillText(`High Score: ${getScore(SCORE_SLOT)} Score: ${score*difficulty}`,10,20);
   const t=Math.max(0,GAME_DURATION-(performance.now()-startTime));ctx.fillText(`Time: ${Math.ceil(t/1000)}s`,canvas.width-100,20);
 }
 
@@ -95,15 +115,12 @@ function gameLoop(){animationId=requestAnimationFrame(gameLoop);update();draw();
 
 function endGame(done){
   cancelAnimationFrame(animationId);
-  if(done){
-    score += 10;
-    saveScore(SCORE_SLOT,score);
-  } else {
-    saveScore(SCORE_SLOT,score);
-  }
+  if(done){score+=10;}
+  const finalScore=score*difficulty;
+  saveScore(SCORE_SLOT,finalScore);
   const best=getScore(SCORE_SLOT);
   overlay.innerHTML=`<h1>${done?'Mission Complete! +10 to score!':'Tank Destroyed'}</h1>
-                     <p>Your score: ${score}</p><p>High Score: ${best}</p>
+                     <p>Your score: ${finalScore}</p><p>High Score: ${best}</p>
                      <button id="playAgain">Play Again</button>`;
   overlay.style.display='flex';
   overlay.querySelector('#playAgain').addEventListener('click',()=>location.reload());


### PR DESCRIPTION
## Summary
- enable difficulty parameter in `tank.html`
- show instructions for URL difficulty parameter
- make enemy HP scale with difficulty
- darken targets as they take damage
- multiply final score by difficulty before saving/displaying

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869ad6f1394832bb95c5664b9193c2f