### PR TITLE
Update button color on profile selection

### DIFF
--- a/profiles.html
+++ b/profiles.html
@@ -46,14 +46,18 @@
     .panel.active {
       display: block;
     }
-    .panel button {
+    .select-btn {
       margin-top: 1rem;
-      background: #10b981;
+      background: #1877f2;
       color: #fff;
       border: none;
       border-radius: 0.5rem;
       padding: 0.5rem 1rem;
       cursor: pointer;
+    }
+
+    .select-btn.selected {
+      background: #10b981;
     }
   </style>
 </head>
@@ -144,9 +148,11 @@
         if (btn.dataset.role === selected) {
           btn.textContent = 'Currently selected';
           btn.disabled = true;
+          btn.classList.add('selected');
         } else {
           btn.textContent = 'Select ' + btn.dataset.role;
           btn.disabled = false;
+          btn.classList.remove('selected');
         }
       });
     }


### PR DESCRIPTION
## Summary
- update default color for profile select buttons to blue
- highlight chosen profile button in green

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6869bee43f50832ba5f7b7287d1feb45