### PR TITLE
Add Apps Script version of card generator

### DIFF
--- a/cardgen/google_cardgen/Code.gs
+++ b/cardgen/google_cardgen/Code.gs
@@ -1,0 +1,18 @@
+function doGet() {
+  return HtmlService.createHtmlOutputFromFile('index')
+      .setTitle('Robot Player‑Card Generator');
+}
+
+function getScores() {
+  var sheetId = 'YOUR_SHEET_ID'; // Replace with your sheet ID
+  var sheet = SpreadsheetApp.openById(sheetId).getSheetByName('Scores');
+  return sheet.getDataRange().getValues();
+}
+
+function createCardPdf() {
+  var html = HtmlService.createHtmlOutputFromFile('index').getContent();
+  var blob = Utilities.newBlob(html, 'text/html', 'card.html');
+  var pdf = blob.getAs('application/pdf').setName('robot_card.pdf');
+  var file = DriveApp.createFile(pdf);
+  return file.getUrl();
+}

--- a/cardgen/google_cardgen/description.js
+++ b/cardgen/google_cardgen/description.js
@@ -1,0 +1,76 @@
+// Functions related to describing the robot card
+function generateBotDescription(botData) {
+  const countryEmojiMap = {
+    us: "\uD83C\uDDFA\uD83C\uDDF8", // United States
+    dk: "\uD83C\uDDE9\uD83C\uDDF0", // Denmark
+    ca: "\uD83C\uDDE8\uD83C\uDDE6", // Canada
+    gb: "\uD83C\uDDEC\uD83C\uDDE7", // United Kingdom
+    de: "\uD83C\uDDE9\uD83C\uDDEA", // Germany
+    fr: "\uD83C\uDDEB\uD83C\uDDF7", // France
+    jp: "\uD83C\uDDEF\uD83C\uDDF5", // Japan
+    cn: "\uD83C\uDDE8\uD83C\uDDF3", // China
+    in: "\uD83C\uDDEE\uD83C\uDDF3", // India
+    kr: "\uD83C\uDDF0\uD83C\uDDF7", // South Korea
+    br: "\uD83C\uDDE7\uD83C\uDDF7", // Brazil
+    se: "\uD83C\uDDF8\uD83C\uDDEA"  // Sweden
+  };
+
+  const languageEmojiMap = {
+    "Java": "\u2615",
+    "Java 11": "\u2615",
+    "C": "\uD83D\uDCBE",
+    "C++": "\uD83D\uDCBB",
+    "Python": "\uD83D\uDC0D",
+    "Python 3": "\uD83D\uDC0D"
+  };
+
+  const {
+    name,
+    version,
+    authors = [],
+    description = "",
+    homepage = "",
+    countryCodes = [],
+    platform = "",
+    programmingLang = ""
+  } = botData;
+
+  const flagEmojis = countryCodes.length > 0
+    ? countryCodes.map(code => countryEmojiMap[code.toLowerCase()] || `\u26f3\uFE0F(${code})`).join(" ")
+    : "";
+  const authorList = authors.length > 0
+    ? authors.map(name => `<div class="author">\uD83D\uDC64 ${name}</div>`).join("")
+    : "";
+  const languageEmoji = languageEmojiMap[programmingLang] || "\uD83D\uDCA1";
+  const siteLink = homepage ? `<a href="${homepage}" target="_blank">Visit Site</a>` : "";
+
+  return `
+        <div style="
+          background: #fbeec1;
+          border: 4px solid #333;
+          border-radius: 12px;
+          padding: 16px;
+          font-family: 'Verdana', sans-serif;
+          box-shadow: 3px 3px 10px rgba(0,0,0,0.3);
+          color: #222;
+        ">
+          <div style="font-size: 1.2em; font-weight: bold;">\uD83E\uDD16 ${name || "Unnamed Bot"} ${version ? `<span style="font-size: 0.7em;">v${version}</span>` : ""}</div>
+          ${flagEmojis ? `<div style="margin: 8px 0;">${flagEmojis}</div>` : ""}
+          ${authorList ? `<div style="margin-bottom: 8px;">${authorList}</div>` : ""}
+          ${description ? `<div style="font-style: italic; margin-bottom: 12px;">${description}</div>` : ""}
+          ${programmingLang ? `<div><strong>\uD83D\uDCBB Language:</strong> ${languageEmoji} ${programmingLang}</div>` : ""}
+          ${siteLink ? `<div><strong>\uD83C\uDF10 Website:</strong> ${siteLink}</div>` : ""}
+        </div>
+      `;
+}
+
+function renderRobotMeta() {
+  const metaEl = document.getElementById("robot-meta");
+  if (!window.robotInfo) {
+    metaEl.style.display = "none";
+    metaEl.innerHTML = "";
+    return;
+  }
+  metaEl.style.display = "block";
+  metaEl.innerHTML = generateBotDescription(window.robotInfo);
+}

--- a/cardgen/google_cardgen/index.html
+++ b/cardgen/google_cardgen/index.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Robot Player‑Card Generator</title>
+  <style>
+    body {
+      font-family: system-ui, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+      background: #f4f7fa;
+      padding: 2rem;
+      line-height: 1.4;
+    }
+
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .preview-wrapper {
+      margin-bottom: 1rem;
+    }
+
+    /* ── Card ───────────────────────────────────────── */
+    .card {
+      width: 320px;
+      padding: 1rem 1.25rem;
+      border-radius: 1rem;
+      background: #fff;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      border: 4px solid transparent;
+      transition: border-color 0.3s ease;
+      position: relative;
+    }
+
+    .card h2 {
+      font-size: 1.35rem;
+      margin: 0 0 0.5rem;
+      word-break: break-word;
+    }
+
+    .stats p {
+      display: flex;
+      justify-content: space-between;
+      margin: 0.15rem 0;
+    }
+
+    .stars {
+      text-align: center;
+      color: #f1c40f;
+      font-size: 1.25rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .logo {
+      position: absolute;
+      top: 0.25rem;
+      left: 0.25rem;
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
+    .player-role {
+      position: absolute;
+      top: 0.25rem;
+      right: 0.25rem;
+      font-size: 1.25rem;
+    }
+
+    /* ── Buttons ────────────────────────────────────── */
+    button {
+      padding: 0.55rem 1rem;
+      border: none;
+      border-radius: 0.6rem;
+      font-size: 0.95rem;
+      cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      transition: transform 0.08s ease;
+    }
+
+    button:hover {
+      transform: translateY(-2px);
+    }
+
+    /* Preview button removed */
+    #download-btn {
+      background: #10b981;
+      color: #fff;
+      display: inline-block;
+    }
+
+    #update-btn {
+      background: #3b82f6;
+      color: #fff;
+      margin-right: 0.5rem;
+    }
+  </style>
+
+  <!-- html2canvas for PNG download -->
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  <!-- Shared helpers provided by your site -->
+  <script src="../shared.js"></script>
+  <script src="description.js"></script>
+  <script src="storage.js"></script>
+  <script src="scoreSheet.js"></script>
+  <script src="main.js"></script>
+</head>
+
+<body>
+  <h1>Robot Player‑Card Generator</h1>
+
+  <div style="margin-bottom:1rem;">
+    <label for="tank-upload">Tank image:</label>
+    <input id="tank-upload" type="file" accept="image/*" style="display:none;" />
+    <button id="edit-image-btn" type="button">Edit Image</button>
+  </div>
+
+  <div style="margin-bottom:1rem;">
+    <label for="json-upload">Robot JSON:</label>
+    <input id="json-upload" type="file" accept="application/json" style="display:none;" />
+    <button id="edit-json-btn" type="button">Edit JSON</button>
+  </div>
+
+  <div style="margin-bottom:1rem;">
+    <label for="scoresheet-upload">Score sheet:</label>
+    <input id="scoresheet-upload" type="file" accept=".txt" style="display:none;" />
+    <button id="edit-scoresheet-btn" type="button">Edit Scoresheet</button>
+  </div>
+
+
+  <div style="margin-bottom:1rem; display:none;">
+    <label for="code-input">Card code:</label>
+    <input id="code-input" type="text" />
+  </div>
+
+  <div class="preview-wrapper">
+    <div id="card" class="card" style="display:none;">
+      <img src="../icon.webp" alt="Infinite Mind logo" class="logo" />
+      <div id="player-role" class="player-role"></div>
+      <div id="star-rating" style="font-size: large;" class="stars"></div>
+      <img id="tank-image" src="" alt="Tank preview"
+        style="width:100%;border-radius:0.5rem;margin-bottom:0.5rem;display:none;" />
+      <h2 id="robot-name"></h2>
+      <!-- GOOD description will be injected here -->
+      <div id="robot-meta" style="font-size:0.85rem;margin-bottom:0.5rem;display:none;"></div>
+      <div class="stats" id="stats"><!-- Injected here --></div>
+    </div>
+  </div>
+
+  <button id="update-btn">Update Card</button>
+  <button id="download-btn">Download PNG</button>
+  <button id="pdf-btn">Download PDF</button>
+
+  <script>
+    // Trigger PDF generation through Apps Script
+    document.getElementById('pdf-btn').addEventListener('click', () => {
+      google.script.run.withSuccessHandler(function(url) {
+        window.open(url);
+      }).createCardPdf();
+    });
+
+    // Load score data from the linked Google Sheet
+    google.script.run.withSuccessHandler(function(rows) {
+      if (Array.isArray(rows)) {
+        const scores = rows.map(r => ({
+          rank: Number(r[0]) || 0,
+          name: r[1] || '',
+          survival: Number(r[2]) || 0,
+          lastSurvivor: Number(r[3]) || 0,
+          bullet: Number(r[4]) || 0,
+          bonus: Number(r[6]) || 0,
+          raw: r.join('\t')
+        }));
+        try {
+          localStorage.setItem('botScoreSheet', JSON.stringify(scores));
+        } catch (err) {
+          console.error('Failed to store scores from sheet', err);
+        }
+      }
+    }).getScores();
+  </script>
+
+</body>
+
+</html>

--- a/cardgen/google_cardgen/main.js
+++ b/cardgen/google_cardgen/main.js
@@ -1,0 +1,211 @@
+// Main logic for the card generator
+const GAME_IDS = [1, 2, 3, 4];
+const MAX_SCORES = { 1: 30, 2: 30, 3: 4, 4: 30 };
+const MAX_TOTAL = Object.values(MAX_SCORES).reduce((a, b) => a + b, 0);
+window.codeBonus = 0;
+window.robotInfo = null;
+window.intervalId = null;
+
+function storeScoresFromSheet(rows) {
+  if (!Array.isArray(rows)) return;
+  const scores = rows.map(r => ({
+    rank: Number(r[0]) || 0,
+    name: r[1] || '',
+    survival: Number(r[2]) || 0,
+    lastSurvivor: Number(r[3]) || 0,
+    bullet: Number(r[4]) || 0,
+    bonus: Number(r[6]) || 0,
+    raw: r.join('\t'),
+  }));
+  try {
+    localStorage.setItem('botScoreSheet', JSON.stringify(scores));
+  } catch (err) {
+    console.error('Failed to store score sheet', err);
+  }
+}
+const ROLE_COLORS = {
+  Explorer: [128, 128, 128],
+  Achiever: [0, 128, 128],
+  Competitor: [218, 165, 32],
+  Harmonizer: [0, 128, 0],
+};
+const ROLE_EMOJIS = {
+  Explorer: "✨",
+  Achiever: "🏆",
+  Competitor: "🔥",
+  Harmonizer: "🤝",
+};
+
+function starsForScore(score, max) {
+  if (score >= max) return 3;
+  if (score >= max * 0.8) return 2;
+  if (score >= max * 0.5) return 1;
+  return 0;
+}
+
+function updateCodeBonus() {
+  const code = document.getElementById("code-input").value.trim();
+  if (/^\d.*[abc]$/.test(code)) {
+    window.codeBonus = (code.match(/%/g) || []).length;
+  } else {
+    window.codeBonus = 0;
+  }
+}
+
+function buildCard() {
+  const statsEl = document.getElementById("stats");
+  const starEl = document.getElementById("star-rating");
+  const roleTitleEl = document.getElementById("player-role");
+  statsEl.innerHTML = "";
+
+  renderRobotMeta();
+
+  let total = 0;
+  let starTotal = 0;
+  GAME_IDS.forEach((id) => {
+    const score = getScore(id) || 0;
+    total += score;
+    starTotal += starsForScore(score, MAX_SCORES[id]);
+  });
+
+  updateCodeBonus();
+
+  let rank = 0;
+  if (window.robotInfo) {
+    try {
+      const sheet = JSON.parse(localStorage.getItem("botScoreSheet") || "[]");
+      const me = sheet.find(
+        (r) => r.name === `${window.robotInfo.name} ${window.robotInfo.version}`
+      );
+      if (me) rank = me.rank || 0;
+    } catch {}
+  }
+
+  const baseStars = Math.min(12, starTotal + window.codeBonus);
+  const starCount = Math.max(0, baseStars - rank);
+  starEl.textContent = "★".repeat(starCount);
+
+  const hue = Math.max(0, Math.min(120, total));
+  let [r1, g1, b1] = hslToRgb(hue, 0.65, 0.4);
+  let [r2, g2, b2] = hslToRgb(hue, 0.65, 0.6);
+  const role = localStorage.getItem("robotCard:role") || "";
+  roleTitleEl.textContent = ROLE_EMOJIS[role] || "";
+  if (ROLE_COLORS[role]) {
+    const [tr, tg, tb] = ROLE_COLORS[role];
+    const mix = (c, t) => Math.round(c * 0.75 + t * 0.25);
+    r1 = mix(r1, tr);
+    g1 = mix(g1, tg);
+    b1 = mix(b1, tb);
+    r2 = mix(r2, tr);
+    g2 = mix(g2, tg);
+    b2 = mix(b2, tb);
+  }
+  const gradient = `linear-gradient(135deg, rgb(${r1}, ${g1}, ${b1}), rgb(${r2}, ${g2}, ${b2}))`;
+  const borderColor = `rgb(${r2}, ${g2}, ${b2})`;
+  const cardEl = document.getElementById("card");
+  cardEl.style.background = gradient;
+  cardEl.style.borderColor = borderColor;
+}
+
+// DOM setup and event bindings
+window.addEventListener('DOMContentLoaded', () => {
+  const uploadEl = document.getElementById("tank-upload");
+  const jsonUploadEl = document.getElementById("json-upload");
+  const scoreSheetUploadEl = document.getElementById("scoresheet-upload");
+  const imgEl = document.getElementById("tank-image");
+  const cardEl = document.getElementById("card");
+  const codeInputEl = document.getElementById("code-input");
+  const editImgBtn = document.getElementById("edit-image-btn");
+  const editJsonBtn = document.getElementById("edit-json-btn");
+  const editSheetBtn = document.getElementById("edit-scoresheet-btn");
+
+  codeInputEl.addEventListener("input", () => {
+    updateCodeBonus();
+    buildCard();
+  });
+
+  editImgBtn.addEventListener("click", () => uploadEl.click());
+  editJsonBtn.addEventListener("click", () => jsonUploadEl.click());
+  editSheetBtn.addEventListener("click", () => scoreSheetUploadEl.click());
+
+  uploadEl.addEventListener("change", (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      imgEl.src = ev.target.result;
+      imgEl.style.display = "block";
+      cardEl.style.display = "block";
+      localStorage.setItem("robotCard:image", ev.target.result);
+      buildCard();
+      if (!window.intervalId) {
+        window.intervalId = setInterval(buildCard, 60000);
+      }
+    };
+    reader.readAsDataURL(file);
+  });
+
+  jsonUploadEl.addEventListener("change", (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        window.robotInfo = JSON.parse(ev.target.result);
+        localStorage.setItem("robotCard:json", ev.target.result);
+      } catch (err) {
+        alert("Invalid JSON file");
+        window.robotInfo = null;
+      }
+      cardEl.style.display = "block";
+      buildCard();
+      if (!window.intervalId) {
+        window.intervalId = setInterval(buildCard, 60000);
+      }
+    };
+    reader.readAsText(file);
+  });
+
+  scoreSheetUploadEl.addEventListener("change", (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      saveScoreSheet(ev.target.result);
+      buildCard();
+      if (!window.intervalId) {
+        window.intervalId = setInterval(buildCard, 60000);
+      }
+    };
+    reader.readAsText(file);
+  });
+
+  document.getElementById("update-btn").addEventListener("click", updateCardFromStorage);
+
+  document.getElementById("download-btn").addEventListener("click", () => {
+    html2canvas(document.getElementById("card"), { scale: 2 }).then((canvas) => {
+      const link = document.createElement("a");
+      link.download = "robot_card.png";
+      link.href = canvas.toDataURL("image/png");
+      link.click();
+    });
+  });
+
+  const pdfBtn = document.getElementById("pdf-btn");
+  if (pdfBtn && google && google.script) {
+    pdfBtn.addEventListener("click", () => {
+      google.script.run.withSuccessHandler(function(url) {
+        window.open(url);
+      }).createCardPdf();
+    });
+  }
+
+  loadStoredData();
+
+  if (google && google.script) {
+    google.script.run.withSuccessHandler((rows) => {
+      storeScoresFromSheet(rows);
+      buildCard();
+    }).getScores();
+  }
+});

--- a/cardgen/google_cardgen/scoreSheet.js
+++ b/cardgen/google_cardgen/scoreSheet.js
@@ -1,0 +1,105 @@
+// Utilities for handling Robocode-style score sheets
+
+/**
+ * @typedef {Object} ScoreRow
+ * @property {number} rank          // Field 1
+ * @property {string} name          // Field 2
+ * @property {number} survival      // Field 3
+ * @property {number} lastSurvivor  // Field 4
+ * @property {number} bullet        // Field 5
+ * @property {number} bonus         // Field 7
+ * @property {string} raw           // Original line
+ */
+
+/**
+ * Parse a raw score sheet string produced by a tournament.
+ * Each line should be tab separated with the fixed field order described
+ * in the README. Only the first seven columns are used.
+ *
+ * @param {string} raw
+ * @returns {ScoreRow[]}
+ */
+function parseScoreSheet(raw) {
+  if (typeof raw !== 'string') return [];
+  return raw
+    .trim()
+    .split(/\r?\n/) // split on newlines
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('\t');
+      return {
+        rank: Number(parts[0]) || 0,
+        name: parts[1] || '',
+        survival: Number(parts[2]) || 0,
+        lastSurvivor: Number(parts[3]) || 0,
+        bullet: Number(parts[4]) || 0,
+        bonus: Number(parts[6]) || 0,
+        raw: line,
+      };
+    });
+}
+
+/**
+ * Parse the given score sheet string and persist it under
+ * localStorage['botScoreSheet'].
+ *
+ * @param {string} raw
+ */
+function saveScoreSheet(raw) {
+  const scores = parseScoreSheet(raw);
+  try {
+    localStorage.setItem('botScoreSheet', JSON.stringify(scores));
+  } catch (err) {
+    console.error('Failed to store score sheet', err);
+  }
+}
+
+/**
+ * Get tint information for a particular row relative to the entire sheet.
+ * This computes tints for survival (green), bullet damage (blue) and bonus
+ * (orange) according to the specification.
+ *
+ * @param {ScoreRow} row  The row to evaluate
+ * @param {ScoreRow[]} all  All rows from the sheet
+ * @returns {{survivalTint:string, bulletTint:string, bonusTint:string}}
+ */
+function getTintInfo(row, all) {
+  if (!row || !Array.isArray(all) || all.length === 0) {
+    return { survivalTint: '', bulletTint: '', bonusTint: '' };
+  }
+
+  const survivalValues = all.map((r) => r.survival);
+  const bonusValues = all.map((r) => r.bonus);
+  const bulletValues = all.map((r) => r.bullet);
+
+  const minSurvival = Math.min.apply(null, survivalValues);
+  const maxSurvival = Math.max.apply(null, survivalValues);
+  const minBonus = Math.min.apply(null, bonusValues);
+  const maxBonus = Math.max.apply(null, bonusValues);
+  const maxBullet = Math.max.apply(null, bulletValues);
+
+  const survivalRange = maxSurvival - minSurvival || 1;
+  const bonusRange = maxBonus - minBonus || 1;
+
+  const survRatio = (row.survival - minSurvival) / survivalRange;
+  const bonusRatio = (row.bonus - minBonus) / bonusRange;
+
+  const survivalOpacity = Math.max(0, Math.min(1, survRatio)) * 0.3;
+  const bonusOpacity = Math.max(0, Math.min(1, bonusRatio)) * 0.3;
+
+  const survivalTint =
+    survivalOpacity > 0
+      ? `rgba(0,255,0,${survivalOpacity.toFixed(2)})`
+      : '';
+  const bonusTint =
+    bonusOpacity > 0 ? `rgba(255,165,0,${bonusOpacity.toFixed(2)})` : '';
+  const bulletTint = row.bullet === maxBullet ? 'rgba(0,0,255,0.3)' : '';
+
+  return { survivalTint, bulletTint, bonusTint };
+}
+
+// expose globals for non-module usage
+window.parseScoreSheet = parseScoreSheet;
+window.saveScoreSheet = saveScoreSheet;
+window.getTintInfo = getTintInfo;
+

--- a/cardgen/google_cardgen/shared.js
+++ b/cardgen/google_cardgen/shared.js
@@ -1,0 +1,73 @@
+function rgbToHsl(r, g, b) {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h, s, l = (max + min) / 2;
+
+  if (max === min) {
+    h = s = 0; // achromatic
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = ((g - b) / d + (g < b ? 6 : 0)); break;
+      case g: h = ((b - r) / d + 2); break;
+      case b: h = ((r - g) / d + 4); break;
+    }
+    h *= 60;
+  }
+
+  return [h, s, l];
+}
+
+function hslToRgb(h, s, l) {
+  const hue2rgb = (p, q, t) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1/6) return p + (q - p) * 6 * t;
+    if (t < 1/2) return q;
+    if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+    return p;
+  };
+
+  let r, g, b;
+  if (s === 0) {
+    r = g = b = l; // achromatic
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : (l + s - l * s);
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, (h / 360 + 1/3));
+    g = hue2rgb(p, q, (h / 360));
+    b = hue2rgb(p, q, (h / 360 - 1/3));
+  }
+
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
+/**
+ * Save a score for the given game only if it's greater than the current high score.
+ * - gameID: any string (e.g. "dodge", "tank")
+ * - score: a number (must be comparable with greater-than operator)
+ */
+function saveScore(gameID, score) {
+  if (!gameID) throw new Error("saveScore: gameID is required");
+  if (typeof score !== 'number') throw new Error("saveScore: score must be a number");
+  
+  const currentHighScore = getScore(gameID);
+  if (score > currentHighScore) {
+    localStorage.setItem(`score:${gameID}`, JSON.stringify(score));
+  }
+}
+
+/**
+ * Retrieve the previously saved high score.
+ * Returns 0 if no score has been saved yet.
+ */
+function getScore(gameID) {
+  if (!gameID) throw new Error("getScore: gameID is required");
+  
+  const raw = localStorage.getItem(`score:${gameID}`);
+  return raw === null ? 0 : JSON.parse(raw);
+}

--- a/cardgen/google_cardgen/storage.js
+++ b/cardgen/google_cardgen/storage.js
@@ -1,0 +1,45 @@
+// Functions for persisting and retrieving card data
+function loadStoredData() {
+  const uploadEl = document.getElementById("tank-upload");
+  const jsonUploadEl = document.getElementById("json-upload");
+  const imgEl = document.getElementById("tank-image");
+  const cardEl = document.getElementById("card");
+  const storedImg = localStorage.getItem("robotCard:image");
+  const storedJson = localStorage.getItem("robotCard:json");
+  const storedRole = localStorage.getItem("robotCard:role");
+  if (storedImg) {
+    imgEl.src = storedImg;
+    imgEl.style.display = "block";
+    cardEl.style.display = "block";
+  }
+  if (storedJson) {
+    try { window.robotInfo = JSON.parse(storedJson); } catch { }
+  }
+  const hasRole = Boolean(storedRole);
+  if (storedImg || storedJson || hasRole) {
+    buildCard();
+    if (!window.intervalId) window.intervalId = setInterval(buildCard, 60000);
+  }
+}
+
+function updateCardFromStorage() {
+  const imgEl = document.getElementById("tank-image");
+  const cardEl = document.getElementById("card");
+  const storedImg = localStorage.getItem("robotCard:image");
+  const storedJson = localStorage.getItem("robotCard:json");
+  const storedRole = localStorage.getItem("robotCard:role");
+  if (storedImg && storedImg !== imgEl.src) {
+    imgEl.src = storedImg;
+    imgEl.style.display = "block";
+    cardEl.style.display = "block";
+  }
+  if (storedJson) {
+    try {
+      const parsed = JSON.parse(storedJson);
+      if (JSON.stringify(parsed) !== JSON.stringify(window.robotInfo)) {
+        window.robotInfo = parsed;
+      }
+    } catch {}
+  }
+  buildCard();
+}


### PR DESCRIPTION
## Summary
- create `google_cardgen` folder with Apps Script version of the player card generator
- include `Code.gs` server script for sheet access and PDF generation
- add modified `index.html` and `main.js` with Apps Script hooks
- copy supporting JS and assets
- reference icon from parent folder instead of copying it

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686eaac5c2d0832bbd1d2d738d78557c