### PR TITLE
Fix bullet score column mapping

### DIFF
--- a/cardgen/google_cardgen/index.html
+++ b/cardgen/google_cardgen/index.html
@@ -306,7 +306,7 @@
             name: parts[1] || '',
             survival: Number(parts[2]) || 0,
             lastSurvivor: Number(parts[3]) || 0,
-            bullet: Number(parts[4]) || 0,
+            bullet: Number(parts[5]) || 0,
             bonus: Number(parts[6]) || 0,
             raw: line,
           };
@@ -373,7 +373,7 @@
         name: r[1] || '',
         survival: Number(r[2]) || 0,
         lastSurvivor: Number(r[3]) || 0,
-        bullet: Number(r[4]) || 0,
+        bullet: Number(r[5]) || 0,
         bonus: Number(r[6]) || 0,
         raw: r.join('\t'),
       }));
@@ -632,7 +632,7 @@
           name: r[1] || '',
           survival: Number(r[2]) || 0,
           lastSurvivor: Number(r[3]) || 0,
-          bullet: Number(r[4]) || 0,
+          bullet: Number(r[5]) || 0,
           bonus: Number(r[6]) || 0,
           raw: r.join('\t')
         }));

--- a/cardgen/scoreSheet.js
+++ b/cardgen/scoreSheet.js
@@ -32,7 +32,7 @@ function parseScoreSheet(raw) {
         name: parts[1] || '',
         survival: Number(parts[2]) || 0,
         lastSurvivor: Number(parts[3]) || 0,
-        bullet: Number(parts[4]) || 0,
+        bullet: Number(parts[5]) || 0,
         bonus: Number(parts[6]) || 0,
         raw: line,
       };


### PR DESCRIPTION
## Summary
- adjust parsing logic to read bullet score from correct column

## Testing
- `node -e "const fs=require('fs');const text=fs.readFileSync('./cardgen/sample-scoresheet.txt','utf8');console.log(text.split(/\n/).length);"`


------
https://chatgpt.com/codex/tasks/task_e_686ed1cd57bc832b906aaf4cbc8f9cb3