### PR TITLE
Update IDs and use game id from Google Form

### DIFF
--- a/cardgen/google_cardgen/Code.gs
+++ b/cardgen/google_cardgen/Code.gs
@@ -3,10 +3,17 @@ function doGet() {
       .setTitle('Robot Player‑Card Generator');
 }
 
-function getScores() {
-  var sheetId = 'YOUR_SHEET_ID'; // Replace with your sheet ID
-  var sheet = SpreadsheetApp.openById(sheetId).getSheetByName('Scores');
-  return sheet.getDataRange().getValues();
+function getScores(gameId) {
+  var sheetId = '19EhI436McUEme9iBLx64C9-s-GWsh19ZUXKpPjwz1sg';
+  var ss = SpreadsheetApp.openById(sheetId);
+  var sheet;
+  if (gameId) {
+    sheet = ss.getSheetByName(String(gameId));
+  }
+  if (!sheet) {
+    sheet = ss.getSheetByName('Scores');
+  }
+  return sheet ? sheet.getDataRange().getValues() : [];
 }
 
 function createCardPdf() {
@@ -18,7 +25,7 @@ function createCardPdf() {
 }
 
 function getFormData() {
-  var formId = 'YOUR_FORM_ID'; // Replace with your form ID
+  var formId = '1F3NQCHt3Ki_6p9dNY6nAFMD_-t6FRbbxTkGUTQh4VXc';
   var form = FormApp.openById(formId);
   var responses = form.getResponses();
   if (responses.length === 0) return {};
@@ -27,10 +34,15 @@ function getFormData() {
   var items = latest.getItemResponses();
   var result = {};
 
-  // By convention the first question contains the JSON text
+  // By convention the first question contains the JSON text,
+  // the second last question holds the game ID,
   // and the last question is a file upload for the tank image.
   if (items.length >= 1) {
     result.json = items[0].getResponse();
+  }
+
+  if (items.length >= 3) {
+    result.gameId = items[items.length - 2].getResponse();
   }
 
   if (items.length >= 2) {

--- a/cardgen/google_cardgen/index.html
+++ b/cardgen/google_cardgen/index.html
@@ -562,13 +562,9 @@
       loadStoredData();
 
       if (google && google.script) {
-        google.script.run.withSuccessHandler((rows) => {
-          storeScoresFromSheet(rows);
-          buildCard();
-        }).getScores();
-
         // Pull latest form submission for card data.
-        // The first form question should contain the JSON text and
+        // The first form question should contain the JSON text,
+        // the second last question stores the game ID, and
         // the last question should be a file upload for the image.
         google.script.run.withSuccessHandler((data) => {
           if (data) {
@@ -586,7 +582,18 @@
               cardEl.style.display = 'block';
               localStorage.setItem('robotCard:image', data.imageDataUrl);
             }
-            buildCard();
+            const gid = data.gameId;
+            if (gid) {
+              google.script.run.withSuccessHandler((rows) => {
+                storeScoresFromSheet(rows);
+                buildCard();
+              }).getScores(gid);
+            } else {
+              google.script.run.withSuccessHandler((rows) => {
+                storeScoresFromSheet(rows);
+                buildCard();
+              }).getScores();
+            }
             if (!window.intervalId) window.intervalId = setInterval(buildCard, 60000);
           }
         }).getFormData();
@@ -648,25 +655,7 @@
       }).createCardPdf();
     });
 
-    // Load score data from the linked Google Sheet
-    google.script.run.withSuccessHandler(function(rows) {
-      if (Array.isArray(rows)) {
-        const scores = rows.map(r => ({
-          rank: Number(r[0]) || 0,
-          name: r[1] || '',
-          survival: Number(r[2]) || 0,
-          lastSurvivor: Number(r[3]) || 0,
-          bullet: Number(r[5]) || 0,
-          bonus: Number(r[6]) || 0,
-          raw: r.join('\t')
-        }));
-        try {
-          localStorage.setItem('botScoreSheet', JSON.stringify(scores));
-        } catch (err) {
-          console.error('Failed to store scores from sheet', err);
-        }
-      }
-    }).getScores();
+    // Score data will be loaded after fetching form details
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- set official form and scoreboard IDs in Apps Script
- add game id handling in the Apps Script backend
- load scores from the sheet that matches the game id
- fetch the sheet only after retrieving the form submission

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ff7169fd4832b863cc1da0c102be4