### PR TITLE
docs: add project readme and move player profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,29 @@
 # WikiMinigames
 
+A collection of browser-based minigames and learning tools built with plain HTML and JavaScript.
 
-**The 4 Main Player Profiles**
+## Getting started
+1. Clone this repository.
+2. Open `index.html` in your browser to browse the available games.
+   - Optionally serve the project with a simple HTTP server such as `python -m http.server`.
 
-Understanding these profiles will help you see what motivates you to learn and play. Here are four main player types, blending Bartle's original taxonomy with newer motivational ideas:
+No build step or external dependencies are required.
 
----
+## Contents
+- `index.html` – landing page linking to all activities.
+- `dodge.html` – arcade-style dodging game.
+- `tank.html` – tank battle minigame.
+- `datatypesquiz.html` – multiple-choice quiz on JavaScript data types.
+- `fillblanks/` – fill-in-the-blank tutorials with `script.js` and `style.css`.
+- `week1test.html` – introductory assessment page.
+- `cardgen/` – robot card generator and Google Apps Script files.
+- `shared.js` – common utilities used across games.
 
-### 1. **Explorer ✨**
+## Player profiles
+The project defines four learner personality profiles used to tailor activities. See [personalities.md](personalities.md) for full descriptions.
 
-**Motivation:** Autonomy, Curiosity, Discovery
-**Catchphrase:** "Let me wander and uncover the secrets."
+## Contributing
+Pull requests are welcome. Please follow the existing coding style and keep changes focused.
 
-Explorers are driven by the joy of discovery. They thrive in environments where they can uncover hidden details, test systems, and experiment without strict time pressure. Their engagement comes from novelty and surprise rather than competition or external rewards.
-
-**Role in Robocode:**
-Everyone begins as an Explorer. You'll start by discovering how bots work and experimenting with movement, sensors, and code. This phase sparks curiosity and lets you uncover strategies at your own pace.
-
-**Fun Tips:**
-
-* Search for hidden treasures and secret spots
-* Try out new moves—you never know what you'll find!
-* Keep exploring different paths to discover surprises
-
-**Stages:** Discovery → Trial → Occupation → Mentor
-**Related Traits:** Scientist, Technician
-
----
-
-### 2. **Achiever 🏆**
-
-**Motivation:** Mastery, Growth, Accomplishment
-**Catchphrase:** "Give me goals and let me prove myself."
-
-Achievers flourish when presented with structured challenges and opportunities for advancement. They enjoy leveling up, mastering skills, and receiving recognition. Socially, they connect with other high performers and often thrive on collaboration with like-minded peers.
-
-**Role in Robocode:**
-As an Achiever, you'll earn the most stars on your player card by scoring high in mini-games and coding challenges. Your path is about growth and visible accomplishment through targeted goals.
-
-**Fun Tips:**
-
-* Collect cool badges and level up
-* Set goals for yourself and celebrate when you hit them
-* Take on skill quests to show what you can do
-
-**Stages:** Ambition → Pursuit → Optimization → Recognition
-**Related Traits:** Planner, Go-Getter
-
----
-
-### 3. **Competitor 🔥**
-
-**Motivation:** Status, Prestige, Victory
-**Catchphrase:** "I want to win—and prove it."
-
-Competitors are achievement-oriented like achievers, but their focus is on *winning against others*. They enjoy leaderboards, ranked play, and opportunities to demonstrate superiority. A competitor's experience is heightened by real-time opposition and public recognition.
-
-**Role in Robocode:**
-As a Competitor, you focus on having the strongest bot in battle. Your code is optimized for tactical superiority, survival, and domination in the arena.
-
-**Fun Tips:**
-
-* Join tournaments to climb the leaderboard
-* Build winning strategies with friends
-* Show off your best moves for bragging rights
-
-**Stages:** Superiority → Tactical → Leadership → Legacy
-**Related Traits:** Leader, Prestige-Seeker
-
----
-
-### 4. **Harmonizer 🤝**
-
-**Motivation:** Belonging, Altruism, Support
-**Catchphrase:** "Let’s build something together."
-
-Harmonizers thrive on connection. They are the glue of any group, always looking to support and uplift others. Teamwork, empathy, and shared goals fuel their engagement. They flourish in cooperative settings and gain satisfaction from helping others succeed.
-
-**Role in Robocode:**
-As a Harmonizer, you help organize the competition. You might create fun chants for tanks, handle event commentary, design advertisements, and support the event's vibe. Your role boosts community spirit and cohesion.
-
-**Fun Tips:**
-
-* Team up on group missions and help each other
-* Share cheers and keep everyone motivated
-* Teach your friends tricks and tips
-
-**Stages:** Connection → Partnership → Community → Impact
-**Related Traits:** Networker, Companion
-
----
-
-These player profiles aren't rigid categories but flexible personas. You might see yourself in more than one. When everyone embraces all four types, every player gets a chance to thrive.
+## License
+This project is provided as-is without a specified license.

--- a/personalities.md
+++ b/personalities.md
@@ -1,0 +1,94 @@
+# Player Profiles
+
+
+**The 4 Main Player Profiles**
+
+Understanding these profiles will help you see what motivates you to learn and play. Here are four main player types, blending Bartle's original taxonomy with newer motivational ideas:
+
+---
+
+### 1. **Explorer ✨**
+
+**Motivation:** Autonomy, Curiosity, Discovery
+**Catchphrase:** "Let me wander and uncover the secrets."
+
+Explorers are driven by the joy of discovery. They thrive in environments where they can uncover hidden details, test systems, and experiment without strict time pressure. Their engagement comes from novelty and surprise rather than competition or external rewards.
+
+**Role in Robocode:**
+Everyone begins as an Explorer. You'll start by discovering how bots work and experimenting with movement, sensors, and code. This phase sparks curiosity and lets you uncover strategies at your own pace.
+
+**Fun Tips:**
+
+* Search for hidden treasures and secret spots
+* Try out new moves—you never know what you'll find!
+* Keep exploring different paths to discover surprises
+
+**Stages:** Discovery → Trial → Occupation → Mentor
+**Related Traits:** Scientist, Technician
+
+---
+
+### 2. **Achiever 🏆**
+
+**Motivation:** Mastery, Growth, Accomplishment
+**Catchphrase:** "Give me goals and let me prove myself."
+
+Achievers flourish when presented with structured challenges and opportunities for advancement. They enjoy leveling up, mastering skills, and receiving recognition. Socially, they connect with other high performers and often thrive on collaboration with like-minded peers.
+
+**Role in Robocode:**
+As an Achiever, you'll earn the most stars on your player card by scoring high in mini-games and coding challenges. Your path is about growth and visible accomplishment through targeted goals.
+
+**Fun Tips:**
+
+* Collect cool badges and level up
+* Set goals for yourself and celebrate when you hit them
+* Take on skill quests to show what you can do
+
+**Stages:** Ambition → Pursuit → Optimization → Recognition
+**Related Traits:** Planner, Go-Getter
+
+---
+
+### 3. **Competitor 🔥**
+
+**Motivation:** Status, Prestige, Victory
+**Catchphrase:** "I want to win—and prove it."
+
+Competitors are achievement-oriented like achievers, but their focus is on *winning against others*. They enjoy leaderboards, ranked play, and opportunities to demonstrate superiority. A competitor's experience is heightened by real-time opposition and public recognition.
+
+**Role in Robocode:**
+As a Competitor, you focus on having the strongest bot in battle. Your code is optimized for tactical superiority, survival, and domination in the arena.
+
+**Fun Tips:**
+
+* Join tournaments to climb the leaderboard
+* Build winning strategies with friends
+* Show off your best moves for bragging rights
+
+**Stages:** Superiority → Tactical → Leadership → Legacy
+**Related Traits:** Leader, Prestige-Seeker
+
+---
+
+### 4. **Harmonizer 🤝**
+
+**Motivation:** Belonging, Altruism, Support
+**Catchphrase:** "Let’s build something together."
+
+Harmonizers thrive on connection. They are the glue of any group, always looking to support and uplift others. Teamwork, empathy, and shared goals fuel their engagement. They flourish in cooperative settings and gain satisfaction from helping others succeed.
+
+**Role in Robocode:**
+As a Harmonizer, you help organize the competition. You might create fun chants for tanks, handle event commentary, design advertisements, and support the event's vibe. Your role boosts community spirit and cohesion.
+
+**Fun Tips:**
+
+* Team up on group missions and help each other
+* Share cheers and keep everyone motivated
+* Teach your friends tricks and tips
+
+**Stages:** Connection → Partnership → Community → Impact
+**Related Traits:** Networker, Companion
+
+---
+
+These player profiles aren't rigid categories but flexible personas. You might see yourself in more than one. When everyone embraces all four types, every player gets a chance to thrive.


### PR DESCRIPTION
## Summary
- add comprehensive project README with setup instructions and file overview
- move player profile descriptions into new `personalities.md`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e67bfe594832bb749f50bdd39ecfc